### PR TITLE
[RHCLOUD-19399] Move to GVK queries and add a schematized query factory method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cover.out
+.vscode

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ counter := resources.ResourceCounter{
 }
 ```
 
+### MakeResourceCounterForType
+A common pattern is what we saw above: make a query for a type and then generate a ResourceCounter for it. The `MakeResourceCounterForType` method will collapse that into one step for you:
+
+```go
+    counter := resources.MakeResourceCounterForType(
+        &apps.Deployment{}, 
+        *scheme, 
+        namespaces, 
+        o.GetUID(),
+        []resources.ResourceConditionReadyRequirements{{
+            Type:   "Available",
+            Status: "True",
+         }}
+    )
+```
+
 ### ResourceList
 ResourceCounter abstracts away ResourceList and provides an API for a bunch of common operations. If you want to perform your own logic with a list of resources you'd want to use ResourceList:
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ Somethings worth noting in the above example:
 * The results will be a `resources.ResourceCounterResults` struct which shows the number of maanaged and ready resources and a report on the broken ones.
 * `ReadyRequirements` is set to a `resources.ResourceConditionReadyRequirements`. This type defines the criteria used to decide that a resource is ready. This is done by looking for a status condition on the resource that matches the provided type and status. This unfortunately differs from resource to resource; for example, a deployment wants type `"Available"` and status `"True"` while Kafka wants type `"Ready"` and status `"True"`
 
+### MakeQuery
+You may want to write a query for an object you don't know the GVK for and that we don't have in `CommonGVKs`. For that you can use the `MakeQuery` function which will accept a `runtime.Scheme` along with other query requirements to build a query. In the example below we pass `MakeQuery` a type specimen - in this case an `apps.Deployment{}` along with a `runtime.Scheme`, namespace string list and a GUID. The resulting query can be used by `ResourceCounter`.
+
+```go
+query, _ := resources.MakeQuery(&apps.Deployment{}, *scheme, namespaces, o.GetUID())
+
+counter := resources.ResourceCounter{
+    Query: query,
+    ReadyRequirements: []resources.ResourceConditionReadyRequirements{{
+        Type:   "Available",
+        Status: "True",
+    }},
+}
+```
+
 ### ResourceList
 ResourceCounter abstracts away ResourceList and provides an API for a bunch of common operations. If you want to perform your own logic with a list of resources you'd want to use ResourceList:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ guid := "2we34-32ed3-33d33-23rd3"
 counter := resources.ResourceCounter{
     Query: resources.ResourceCounterQuery{
         Namespaces: namespaces,
-        OfType:     &apps.Deployment{},
+        GVK:     CommonGVKs.Deployment,
         OwnerGUID: guid,
     },
     ReadyRequirements: []resources.ResourceConditionReadyRequirements{
@@ -53,11 +53,11 @@ deployments := ResourceList{}
 deployments.GetByGVKAndNamespace(client, context, namespace, gvk)
 ```
 
-The code above would populate the resource list with resources of a given GVK for a given namespace. Note that in real life you'd likely infer the GVK from something that implements `client.Object`:
+The code above would populate the resource list with resources of a given GVK for a given namespace. We provide a struct with common GVKs for things we often status check:
 
 ```go
-	ofType := &apps.Deployemnt{}
-	resources.GetByGVKAndNamespace(pClient, ctx, namespace, ofType.GetObjectKind().GroupVersionKind())
+	gvk := resources.CommonGVKs.Deployment
+	resources.GetByGVKAndNamespace(pClient, ctx, namespace, gvk)
 ```
 
 A number of useful operations could then be performed on the list:

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -83,6 +83,21 @@ func MakeResource(source unstructured.Unstructured) Resource {
 	return res
 }
 
+//Encapsulates the logic for making a query and returning a resource counter in one method call
+func MakeResourceCounterForType(typeSpecimen client.Object, scheme runtime.Scheme, namespaces []string, uid types.UID, readyRequirements []ResourceConditionReadyRequirements) (ResourceCounter, error) {
+	query, err := MakeQuery(typeSpecimen, scheme, namespaces, uid)
+	if err != nil {
+		return ResourceCounter{}, err
+	}
+
+	counter := ResourceCounter{
+		Query:             query,
+		ReadyRequirements: readyRequirements,
+	}
+
+	return counter, nil
+}
+
 func MakeQuery(typeSpecimen client.Object, scheme runtime.Scheme, namespaces []string, uid types.UID) (ResourceCounterQuery, error) {
 	gvk, _, err := scheme.ObjectKinds(typeSpecimen)
 	if err != nil {

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -11,6 +11,36 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type GVKs struct {
+	Deployment   schema.GroupVersionKind
+	Kafka        schema.GroupVersionKind
+	KafkaTopic   schema.GroupVersionKind
+	KafkaConnect schema.GroupVersionKind
+}
+
+var CommonGVKs = GVKs{
+	Deployment: schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	},
+	Kafka: schema.GroupVersionKind{
+		Group:   "kafka.strimzi.io",
+		Version: "v1beta2",
+		Kind:    "Kafka",
+	},
+	KafkaConnect: schema.GroupVersionKind{
+		Group:   "kafka.strimzi.io",
+		Version: "v1beta2",
+		Kind:    "KafkaConnect",
+	},
+	KafkaTopic: schema.GroupVersionKind{
+		Group:   "kafka.strimzi.io",
+		Version: "v1beta2",
+		Kind:    "KafkaTopic",
+	},
+}
+
 //An operator is interested in how many of a resource it manages and how many are ready
 type ResourceFigures struct {
 	Total int32
@@ -292,7 +322,7 @@ type ResourceCounterResults struct {
 //Represents a resource query for a count
 //We count resources of a given GVK (which derive from OfType ), in a given set of namespaces, owned by a given guid
 type ResourceCounterQuery struct {
-	OfType     client.Object
+	GVK        schema.GroupVersionKind
 	Namespaces []string
 	OwnerGUID  string
 }
@@ -333,8 +363,7 @@ func (r *ResourceCounter) countInNamespace(resources ResourceList) {
 
 func (r *ResourceCounter) GetResourceList(pClient client.Client, ctx context.Context, namespace string) ResourceList {
 	resources := ResourceList{}
-	gvk := r.Query.OfType.GetObjectKind().GroupVersionKind()
-	resources.GetByGVKAndNamespace(pClient, ctx, namespace, gvk)
+	resources.GetByGVKAndNamespace(pClient, ctx, namespace, r.Query.GVK)
 	return resources
 }
 

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -79,6 +81,20 @@ func MakeResource(source unstructured.Unstructured) Resource {
 	res.parseStatus(source)
 
 	return res
+}
+
+func MakeQuery(typeSpecimen client.Object, scheme runtime.Scheme, namespaces []string, uid types.UID) (ResourceCounterQuery, error) {
+	gvk, _, err := scheme.ObjectKinds(typeSpecimen)
+	if err != nil {
+		return ResourceCounterQuery{}, err
+	}
+	return ResourceCounterQuery{
+		Namespaces: namespaces,
+		//This creeps me out and I do not like it
+		//Assuming the first entry is right feels very fly by night
+		GVK:       gvk[0],
+		OwnerGUID: string(uid),
+	}, nil
 }
 
 //Represents a k8s resource in a type-neutral way

--- a/resources/resources_test.go
+++ b/resources/resources_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -231,7 +230,7 @@ func TestResourceCounterMixedMultipleNamespaces(t *testing.T) {
 		Query: ResourceCounterQuery{
 			Namespaces: []string{"some-namespace", "some-other-namespace"},
 			OwnerGUID:  GUID,
-			OfType:     &apps.Deployment{},
+			GVK:        CommonGVKs.Deployment,
 		},
 		ReadyRequirements: []ResourceConditionReadyRequirements{
 			{
@@ -272,7 +271,7 @@ func TestResourceCounterMixedSingleNamespaces(t *testing.T) {
 		Query: ResourceCounterQuery{
 			Namespaces: []string{"some-namespace"},
 			OwnerGUID:  GUID,
-			OfType:     &apps.Deployment{},
+			GVK:        CommonGVKs.Deployment,
 		},
 		ReadyRequirements: []ResourceConditionReadyRequirements{
 			{


### PR DESCRIPTION
We infer GVK for queries from a provided Object but in testing this seems unreliable. For example, Deployment often has an empty GVK - I don't know why. This refactor uses GVK instead, but provides a public type that has common GVKs in it. 

Creating this in draft for testing in Clowder and Front End.