### PR TITLE
[RHCLOUD-20042] - Make type asserts safe and fortify testing

### DIFF
--- a/resources/resources.go
+++ b/resources/resources.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/RedHatInsights/rhc-osdk-utils/safe_asserts"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -206,17 +208,6 @@ func (r *Resource) parseStatus(source unstructured.Unstructured) {
 	}
 }
 
-//We perform many type asserts in this code as we pull values from the unstructured
-//objects. We need to handle these safely so as to avoid panics
-func safeStringTypeAssert(sourceMap map[string]interface{}, key string) (string, bool) {
-	outString := ""
-	assertedString, assertionSuccess := sourceMap[key].(string)
-	if assertionSuccess {
-		outString = assertedString
-	}
-	return outString, assertionSuccess
-}
-
 //Parses the unstructured source metadata conditions into this Resource objects Conditions array of maps
 func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 	status := source.Object["status"].(map[string]interface{})
@@ -229,15 +220,16 @@ func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 	}
 
 	//Get the conditions from the status object as an array
-	conditions := status["conditions"].([]interface{})
+	//conditions, _ := status["conditions"].([]interface{})
+	conditions, _ := safe_asserts.InterfaceFromMapToInterfaceList(status, "conditions")
 	//Iterate over the conditions
 	for _, condition := range conditions {
 		//Get the condition as a map
 		conditionMap := condition.(map[string]interface{})
 		//Get the condition parts
-		condStatus, _ := safeStringTypeAssert(conditionMap, "status")
-		condType, _ := safeStringTypeAssert(conditionMap, "type")
-		condReason, reasonNotNil := safeStringTypeAssert(conditionMap, "reason")
+		condStatus, _ := safe_asserts.InterfaceFromMapToString(conditionMap, "status")
+		condType, _ := safe_asserts.InterfaceFromMapToString(conditionMap, "type")
+		condReason, reasonNotNil := safe_asserts.InterfaceFromMapToString(conditionMap, "reason")
 		//Package the conditions up into an easy to use format
 		outputConditionMap := map[string]string{
 			"status": condStatus,

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -206,6 +206,16 @@ func (r *Resource) parseStatus(source unstructured.Unstructured) {
 	}
 }
 
+//We perform many type asserts in this code as we pull values from the unstructured
+//objects. We need to handle these safely so as to avoid panics
+func safeStringTypeAssert(sourceMap map[string]interface{}, key string) (string, bool) {
+	assertedString, assertionSuccess := sourceMap[key].(string)
+	if assertionSuccess {
+		return assertedString, assertionSuccess
+	}
+	return "", false
+}
+
 //Parses the unstructured source metadata conditions into this Resource objects Conditions array of maps
 func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 	status := source.Object["status"].(map[string]interface{})
@@ -224,9 +234,9 @@ func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 		//Get the condition as a map
 		conditionMap := condition.(map[string]interface{})
 		//Get the condition parts
-		condStatus := conditionMap["status"].(string)
-		condType := conditionMap["type"].(string)
-		condReason, reasonNotNil := conditionMap["reason"].(string)
+		condStatus, _ := safeStringTypeAssert(conditionMap, "status")
+		condType, _ := safeStringTypeAssert(conditionMap, "type")
+		condReason, reasonNotNil := safeStringTypeAssert(conditionMap, "reason")
 		//Package the conditions up into an easy to use format
 		outputConditionMap := map[string]string{
 			"status": condStatus,

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -224,7 +224,8 @@ func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 	//Iterate over the conditions
 	for _, condition := range conditions {
 		//Get the condition as a map
-		conditionMap := condition.(map[string]interface{})
+		//conditionMap := condition.(map[string]interface{})
+		conditionMap, _ := safe_asserts.ToMap(condition)
 		//Get the condition parts
 		condStatus, _ := safe_asserts.GetString(conditionMap, "status")
 		condType, _ := safe_asserts.GetString(conditionMap, "type")

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -193,9 +193,9 @@ func (r *Resource) interfaceMapHasKey(inMap map[string]interface{}, key string) 
 
 //Parses a subset of the unstructures source status
 func (r *Resource) parseStatus(source unstructured.Unstructured) {
-	statusSource := safe_asserts.GetMap(source.Object, "status")
+	statusSource, _ := safe_asserts.GetMap(source.Object, "status")
 
-	observedGen := safe_asserts.GetInt64(statusSource, "observedGeneration", -1)
+	observedGen, _ := safe_asserts.GetInt64(statusSource, "observedGeneration", -1)
 
 	r.Status = ResourceStatus{
 		ObservedGeneration: observedGen,
@@ -204,7 +204,7 @@ func (r *Resource) parseStatus(source unstructured.Unstructured) {
 
 //Parses the unstructured source metadata conditions into this Resource objects Conditions array of maps
 func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
-	status := safe_asserts.GetMap(source.Object, "status")
+	status, _ := safe_asserts.GetMap(source.Object, "status")
 
 	//If the source object doesn't have conditions we can just bail
 	//They don't need to be there, we'll just get not ready without them which is fine
@@ -214,14 +214,14 @@ func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 	}
 
 	//Get the conditions from the status object as an array
-	conditions := safe_asserts.GetInterfaceList(status, "conditions")
+	conditions, _ := safe_asserts.GetInterfaceList(status, "conditions")
 	//Iterate over the conditions
 	for _, condition := range conditions {
 		//Get the condition as a map
-		conditionMap := safe_asserts.ToMap(condition)
+		conditionMap, _ := safe_asserts.ToMap(condition)
 		//Get the condition parts
-		condStatus := safe_asserts.GetString(conditionMap, "status")
-		condType := safe_asserts.GetString(conditionMap, "type")
+		condStatus, _ := safe_asserts.GetString(conditionMap, "status")
+		condType, _ := safe_asserts.GetString(conditionMap, "type")
 		//Package the conditions up into an easy to use format
 		outputConditionMap := map[string]string{
 			"status": condStatus,

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -193,9 +193,9 @@ func (r *Resource) interfaceMapHasKey(inMap map[string]interface{}, key string) 
 
 //Parses a subset of the unstructures source status
 func (r *Resource) parseStatus(source unstructured.Unstructured) {
-	statusSource, _ := safe_asserts.GetMap(source.Object, "status")
+	statusSource := safe_asserts.GetMap(source.Object, "status")
 
-	observedGen, _ := safe_asserts.GetInt64(statusSource, "observedGeneration", -1)
+	observedGen := safe_asserts.GetInt64(statusSource, "observedGeneration", -1)
 
 	r.Status = ResourceStatus{
 		ObservedGeneration: observedGen,
@@ -204,7 +204,7 @@ func (r *Resource) parseStatus(source unstructured.Unstructured) {
 
 //Parses the unstructured source metadata conditions into this Resource objects Conditions array of maps
 func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
-	status, _ := safe_asserts.GetMap(source.Object, "status")
+	status := safe_asserts.GetMap(source.Object, "status")
 
 	//If the source object doesn't have conditions we can just bail
 	//They don't need to be there, we'll just get not ready without them which is fine
@@ -214,14 +214,14 @@ func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 	}
 
 	//Get the conditions from the status object as an array
-	conditions, _ := safe_asserts.GetInterfaceList(status, "conditions")
+	conditions := safe_asserts.GetInterfaceList(status, "conditions")
 	//Iterate over the conditions
 	for _, condition := range conditions {
 		//Get the condition as a map
-		conditionMap, _ := safe_asserts.ToMap(condition)
+		conditionMap := safe_asserts.ToMap(condition)
 		//Get the condition parts
-		condStatus, _ := safe_asserts.GetString(conditionMap, "status")
-		condType, _ := safe_asserts.GetString(conditionMap, "type")
+		condStatus := safe_asserts.GetString(conditionMap, "status")
+		condType := safe_asserts.GetString(conditionMap, "type")
 		//Package the conditions up into an easy to use format
 		outputConditionMap := map[string]string{
 			"status": condStatus,

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -226,12 +226,14 @@ func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 		//Get the condition parts
 		condStatus := conditionMap["status"].(string)
 		condType := conditionMap["type"].(string)
-		condReason := conditionMap["reason"].(string)
+		condReason, reasonNotNil := conditionMap["reason"].(string)
 		//Package the conditions up into an easy to use format
 		outputConditionMap := map[string]string{
 			"status": condStatus,
 			"type":   condType,
-			"reason": condReason,
+		}
+		if reasonNotNil {
+			outputConditionMap["reason"] = condReason
 		}
 		//Add it to the output
 		r.Conditions = append(r.Conditions, outputConditionMap)

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -220,16 +220,14 @@ func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 	}
 
 	//Get the conditions from the status object as an array
-	//conditions, _ := status["conditions"].([]interface{})
-	conditions, _ := safe_asserts.InterfaceFromMapToInterfaceList(status, "conditions")
+	conditions, _ := safe_asserts.GetInterfaceList(status, "conditions")
 	//Iterate over the conditions
 	for _, condition := range conditions {
 		//Get the condition as a map
 		conditionMap := condition.(map[string]interface{})
 		//Get the condition parts
-		condStatus, _ := safe_asserts.InterfaceFromMapToString(conditionMap, "status")
-		condType, _ := safe_asserts.InterfaceFromMapToString(conditionMap, "type")
-		condReason, reasonNotNil := safe_asserts.InterfaceFromMapToString(conditionMap, "reason")
+		condStatus, _ := safe_asserts.GetString(conditionMap, "status")
+		condType, _ := safe_asserts.GetString(conditionMap, "type")
 		//Package the conditions up into an easy to use format
 		outputConditionMap := map[string]string{
 			"status": condStatus,
@@ -237,6 +235,7 @@ func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 		}
 		//Reason is different from its siblings because it is valid for it to be omitted
 		//So we pop it on the output conditionally
+		condReason, reasonNotNil := safe_asserts.GetString(conditionMap, "reason")
 		if reasonNotNil {
 			outputConditionMap["reason"] = condReason
 		}

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -193,15 +193,9 @@ func (r *Resource) interfaceMapHasKey(inMap map[string]interface{}, key string) 
 
 //Parses a subset of the unstructures source status
 func (r *Resource) parseStatus(source unstructured.Unstructured) {
-	statusSource := source.Object["status"].(map[string]interface{})
+	statusSource, _ := safe_asserts.GetMap(source.Object, "status")
 
-	//observed
-	var observedGen int64
-	observedGen = -1
-
-	if r.interfaceMapHasKey(statusSource, "observedGeneration") {
-		observedGen = statusSource["observedGeneration"].(int64)
-	}
+	observedGen, _ := safe_asserts.GetInt64(statusSource, "observedGeneration", -1)
 
 	r.Status = ResourceStatus{
 		ObservedGeneration: observedGen,
@@ -210,7 +204,7 @@ func (r *Resource) parseStatus(source unstructured.Unstructured) {
 
 //Parses the unstructured source metadata conditions into this Resource objects Conditions array of maps
 func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
-	status := source.Object["status"].(map[string]interface{})
+	status, _ := safe_asserts.GetMap(source.Object, "status")
 
 	//If the source object doesn't have conditions we can just bail
 	//They don't need to be there, we'll just get not ready without them which is fine
@@ -224,7 +218,6 @@ func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 	//Iterate over the conditions
 	for _, condition := range conditions {
 		//Get the condition as a map
-		//conditionMap := condition.(map[string]interface{})
 		conditionMap, _ := safe_asserts.ToMap(condition)
 		//Get the condition parts
 		condStatus, _ := safe_asserts.GetString(conditionMap, "status")

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -209,11 +209,12 @@ func (r *Resource) parseStatus(source unstructured.Unstructured) {
 //We perform many type asserts in this code as we pull values from the unstructured
 //objects. We need to handle these safely so as to avoid panics
 func safeStringTypeAssert(sourceMap map[string]interface{}, key string) (string, bool) {
+	outString := ""
 	assertedString, assertionSuccess := sourceMap[key].(string)
 	if assertionSuccess {
-		return assertedString, assertionSuccess
+		outString = assertedString
 	}
-	return "", false
+	return outString, assertionSuccess
 }
 
 //Parses the unstructured source metadata conditions into this Resource objects Conditions array of maps
@@ -242,6 +243,8 @@ func (r *Resource) parseStatusConditions(source unstructured.Unstructured) {
 			"status": condStatus,
 			"type":   condType,
 		}
+		//Reason is different from its siblings because it is valid for it to be omitted
+		//So we pop it on the output conditionally
 		if reasonNotNil {
 			outputConditionMap["reason"] = condReason
 		}

--- a/resources/resources_test.go
+++ b/resources/resources_test.go
@@ -137,10 +137,168 @@ var JSONDeploymentNoReason = `
 }
 `
 
+var JSONDeploymentConditionNoStatus = `
+{
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"metadata": {
+		"generation": 4,
+		"namespace": "some-other-namespace",
+		"name": "some-resource",
+		"uid": "1212-1212-1212-1212",
+		"resourceVersion": "1",
+		"ownerReferences" : [
+			{"uid": "` + GUID + `"},
+			{"uid": "2323-2323-2323-2323"}
+		]
+	},
+	"status": {
+		"observedGeneration": 1,
+		"conditions": [
+			{"jomo": "Ready", "type": "Available"},
+			{"jomo": "Yeah", "type": "Happy", "reason": "But Alpha Games better captures that hectic early 00's London indie rock sound."}
+		]
+	}
+}
+`
+
+var JSONDeploymentConditionNoType = `
+{
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"metadata": {
+		"generation": 4,
+		"namespace": "some-other-namespace",
+		"name": "some-resource",
+		"uid": "1212-1212-1212-1212",
+		"resourceVersion": "1",
+		"ownerReferences" : [
+			{"uid": "` + GUID + `"},
+			{"uid": "2323-2323-2323-2323"}
+		]
+	},
+	"status": {
+		"observedGeneration": 1,
+		"conditions": [
+			{"status": "Ready", "fromo": "Available"},
+			{"status": "Yeah", "fromo": "Happy", "reason": "But Alpha Games better captures that hectic early 00's London indie rock sound."}
+		]
+	}
+}
+`
+
+var JSONDeploymentNoStatus = `
+{
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"metadata": {
+		"generation": 4,
+		"namespace": "some-other-namespace",
+		"name": "some-resource",
+		"uid": "1212-1212-1212-1212",
+		"resourceVersion": "1",
+		"ownerReferences" : [
+			{"uid": "` + GUID + `"},
+			{"uid": "2323-2323-2323-2323"}
+		]
+	},
+}
+`
+
+var JSONDeploymentNoMetadata = `
+{
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"status": {
+		"observedGeneration": 1,
+		"conditions": [
+			{"status": "Ready", "type": "Available"},
+			{"status": "Yeah", "type": "Happy", "reason": "But Alpha Games better captures that hectic early 00's London indie rock sound."}
+		]
+	}
+}
+`
+
+func TestDeploymentConditionWithNoStatus(t *testing.T) {
+	uList := unstructured.UnstructuredList{}
+
+	uList.Items = append(uList.Items, ConvertJSONToUnstructured(JSONDeploymentConditionNoStatus))
+
+	rl := ResourceList{}
+	rl.SetListAndParse(uList)
+
+	rl.AddReadyRequirementsFromSlice([]ResourceConditionReadyRequirements{
+		{
+			Type:   "Available",
+			Status: "Ready",
+		},
+	})
+
+	assert.Equal(t, rl.Count(), len(uList.Items))
+	assert.Equal(t, 0, rl.CountReady())
+}
+
+func TestDeploymentConditionWithNoType(t *testing.T) {
+	uList := unstructured.UnstructuredList{}
+
+	uList.Items = append(uList.Items, ConvertJSONToUnstructured(JSONDeploymentConditionNoType))
+
+	rl := ResourceList{}
+	rl.SetListAndParse(uList)
+
+	rl.AddReadyRequirementsFromSlice([]ResourceConditionReadyRequirements{
+		{
+			Type:   "Available",
+			Status: "Ready",
+		},
+	})
+
+	assert.Equal(t, rl.Count(), len(uList.Items))
+	assert.Equal(t, 0, rl.CountReady())
+}
+
+func TestDeploymentWithNoMetadata(t *testing.T) {
+	uList := unstructured.UnstructuredList{}
+
+	uList.Items = append(uList.Items, ConvertJSONToUnstructured(JSONDeploymentNoMetadata))
+
+	rl := ResourceList{}
+	rl.SetListAndParse(uList)
+
+	rl.AddReadyRequirementsFromSlice([]ResourceConditionReadyRequirements{
+		{
+			Type:   "Available",
+			Status: "Ready",
+		},
+	})
+
+	assert.Equal(t, rl.Count(), len(uList.Items))
+	assert.Equal(t, 1, rl.CountReady())
+}
+
 func TestConditionWithNoReason(t *testing.T) {
 	uList := unstructured.UnstructuredList{}
 
 	uList.Items = append(uList.Items, ConvertJSONToUnstructured(JSONDeploymentNoReason))
+
+	rl := ResourceList{}
+	rl.SetListAndParse(uList)
+
+	rl.AddReadyRequirementsFromSlice([]ResourceConditionReadyRequirements{
+		{
+			Type:   "Available",
+			Status: "Ready",
+		},
+	})
+
+	assert.Equal(t, rl.Count(), len(uList.Items))
+	assert.Equal(t, 0, rl.CountReady())
+}
+
+func TestDeploymentWithNoStatus(t *testing.T) {
+	uList := unstructured.UnstructuredList{}
+
+	uList.Items = append(uList.Items, ConvertJSONToUnstructured(JSONDeploymentNoStatus))
 
 	rl := ResourceList{}
 	rl.SetListAndParse(uList)

--- a/safe_asserts/safe_asserts.go
+++ b/safe_asserts/safe_asserts.go
@@ -20,3 +20,12 @@ func GetInterfaceList(sourceInterface map[string]interface{}, key string) ([]int
 	}
 	return outList, assertionSuccess
 }
+
+func ToMap(sourceInterface interface{}) (map[string]interface{}, bool) {
+	outMap := map[string]interface{}{}
+	assertedMap, assertionSuccess := sourceInterface.(map[string]interface{})
+	if assertionSuccess {
+		outMap = assertedMap
+	}
+	return outMap, assertionSuccess
+}

--- a/safe_asserts/safe_asserts.go
+++ b/safe_asserts/safe_asserts.go
@@ -3,7 +3,7 @@ package safe_asserts
 //We perform many type asserts in this code as we pull values from the unstructured
 //objects. We need to handle these safely so as to avoid panics
 
-func InterfaceFromMapToString(sourceMap map[string]interface{}, key string) (string, bool) {
+func GetString(sourceMap map[string]interface{}, key string) (string, bool) {
 	outString := ""
 	assertedString, assertionSuccess := sourceMap[key].(string)
 	if assertionSuccess {
@@ -12,7 +12,7 @@ func InterfaceFromMapToString(sourceMap map[string]interface{}, key string) (str
 	return outString, assertionSuccess
 }
 
-func InterfaceFromMapToInterfaceList(sourceInterface map[string]interface{}, key string) ([]interface{}, bool) {
+func GetInterfaceList(sourceInterface map[string]interface{}, key string) ([]interface{}, bool) {
 	outList := []interface{}{}
 	assertedList, assertionSuccess := sourceInterface[key].([]interface{})
 	if assertionSuccess {

--- a/safe_asserts/safe_asserts.go
+++ b/safe_asserts/safe_asserts.go
@@ -1,0 +1,22 @@
+package safe_asserts
+
+//We perform many type asserts in this code as we pull values from the unstructured
+//objects. We need to handle these safely so as to avoid panics
+
+func InterfaceFromMapToString(sourceMap map[string]interface{}, key string) (string, bool) {
+	outString := ""
+	assertedString, assertionSuccess := sourceMap[key].(string)
+	if assertionSuccess {
+		outString = assertedString
+	}
+	return outString, assertionSuccess
+}
+
+func InterfaceFromMapToInterfaceList(sourceInterface map[string]interface{}, key string) ([]interface{}, bool) {
+	outList := []interface{}{}
+	assertedList, assertionSuccess := sourceInterface[key].([]interface{})
+	if assertionSuccess {
+		outList = assertedList
+	}
+	return outList, assertionSuccess
+}

--- a/safe_asserts/safe_asserts.go
+++ b/safe_asserts/safe_asserts.go
@@ -1,8 +1,13 @@
 package safe_asserts
 
-//We perform many type asserts in this code as we pull values from the unstructured
-//objects. We need to handle these safely so as to avoid panics
+/*
+There are manyaces in this library, specifically in the resource code, that
+we need to perform type assertions. These assertions need to be hanled safely,
+to avoid panics, and must handle various cases like pulling from complex
+structures, default values, etc.
+*/
 
+//Gets a string value from an interface map.
 func GetString(sourceMap map[string]interface{}, key string) (string, bool) {
 	outString := ""
 	assertedString, assertionSuccess := sourceMap[key].(string)
@@ -12,20 +17,56 @@ func GetString(sourceMap map[string]interface{}, key string) (string, bool) {
 	return outString, assertionSuccess
 }
 
+//Gets an interface list from an interface map.
 func GetInterfaceList(sourceInterface map[string]interface{}, key string) ([]interface{}, bool) {
 	outList := []interface{}{}
-	assertedList, assertionSuccess := sourceInterface[key].([]interface{})
-	if assertionSuccess {
-		outList = assertedList
+	success := false
+	value, valueExists := sourceInterface[key]
+	if valueExists {
+		assertedList, assertionSuccess := value.([]interface{})
+		if assertionSuccess {
+			outList = assertedList
+			success = assertionSuccess
+		}
 	}
-	return outList, assertionSuccess
+
+	return outList, success
 }
 
+//Converts a an interface to an interface map.
 func ToMap(sourceInterface interface{}) (map[string]interface{}, bool) {
 	outMap := map[string]interface{}{}
+	success := false
 	assertedMap, assertionSuccess := sourceInterface.(map[string]interface{})
 	if assertionSuccess {
 		outMap = assertedMap
+		success = assertionSuccess
 	}
-	return outMap, assertionSuccess
+	return outMap, success
+}
+
+//Gets an interface map from an interface map
+func GetMap(sourceInterface map[string]interface{}, key string) (map[string]interface{}, bool) {
+	outMap := map[string]interface{}{}
+	success := false
+	value, valueExists := sourceInterface[key]
+	if valueExists {
+		outMap, success = ToMap(value)
+	}
+	return outMap, success
+}
+
+//Gets an int64 from an interface map.
+func GetInt64(sourceInterface map[string]interface{}, key string, defaultVal int64) (int64, bool) {
+	outInt64 := defaultVal
+	success := false
+	value, valueExists := sourceInterface[key]
+	if valueExists {
+		assertedInt64, assertionSuccess := value.(int64)
+		if assertionSuccess {
+			outInt64 = assertedInt64
+			success = assertionSuccess
+		}
+	}
+	return outInt64, success
 }

--- a/safe_asserts/safe_asserts_test.go
+++ b/safe_asserts/safe_asserts_test.go
@@ -1,0 +1,99 @@
+package safe_asserts
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetString(t *testing.T) {
+	sourceMap := map[string]interface{}{
+		"key": "value",
+	}
+	outString, success := GetString(sourceMap, "key")
+	assert.True(t, success)
+	assert.Equal(t, "value", outString)
+
+}
+
+func TestGetStringBadKey(t *testing.T) {
+	sourceMap := map[string]interface{}{
+		"jomo": "value",
+	}
+	_, success := GetString(sourceMap, "key")
+	assert.False(t, success)
+
+}
+
+func TestGetInterfaceList(t *testing.T) {
+	sourceInterface := map[string]interface{}{
+		"jomo": []interface{}{1, 2, 3},
+	}
+	_, success := GetInterfaceList(sourceInterface, "key")
+	assert.False(t, success)
+}
+
+func TestGetInterfaceListBadKey(t *testing.T) {
+	sourceInterface := map[string]interface{}{
+		"key": []interface{}{1, 2, 3},
+	}
+	outList, success := GetInterfaceList(sourceInterface, "key")
+	assert.True(t, success)
+	assert.Equal(t, outList[0], 1)
+}
+
+func TestToMap(t *testing.T) {
+	sourceJSON := []byte(`{"vals": [{"testKey":"testValue"}]}`)
+	var testInterface interface{}
+	json.Unmarshal(sourceJSON, &testInterface)
+	outMap, success := ToMap(testInterface)
+	assert.True(t, success)
+	assert.Equal(t, outMap["vals"].([]interface{})[0].(map[string]interface{})["testKey"], "testValue")
+}
+
+func TestToMapBadAssert(t *testing.T) {
+	_, success := ToMap(map[string]string{"wont": "work"})
+	assert.False(t, success)
+}
+
+func TestGetMap(t *testing.T) {
+	sourceJSON := []byte(`{"vals": [{"testKey":"testValue"}]}`)
+	var testInterface interface{}
+	json.Unmarshal(sourceJSON, &testInterface)
+	sourceMap := map[string]interface{}{
+		"test": testInterface,
+	}
+	outMap, success := GetMap(sourceMap, "test")
+	assert.True(t, success)
+	assert.Equal(t, outMap["vals"].([]interface{})[0].(map[string]interface{})["testKey"], "testValue")
+}
+
+func TestGetMapBadKey(t *testing.T) {
+	sourceJSON := []byte(`{"jomo": [{"testKey":"testValue"}]}`)
+	var testInterface interface{}
+	json.Unmarshal(sourceJSON, &testInterface)
+	sourceMap := map[string]interface{}{
+		"quozo": testInterface,
+	}
+	_, success := GetMap(sourceMap, "test")
+	assert.False(t, success)
+}
+
+func TestGetInt64(t *testing.T) {
+	sourceMap := map[string]interface{}{
+		"key": int64(1979),
+	}
+	outInt64, success := GetInt64(sourceMap, "key", 0)
+	assert.True(t, success)
+	assert.Equal(t, int64(1979), outInt64)
+}
+
+func TestGetInt64DefaultValue(t *testing.T) {
+	sourceMap := map[string]interface{}{
+		"jomo": int64(1979),
+	}
+	outInt64, success := GetInt64(sourceMap, "key", -1)
+	assert.False(t, success)
+	assert.Equal(t, int64(-1), outInt64)
+}


### PR DESCRIPTION
This patch adds a layer of safety to type asserts by wrapping all of them in functions that check for values, handle errors, provide defaults, and communicate success/failure. Full test coverage is added for the new safe assert API. Additionally new tests to check for various possible failure cases due to malformed resources are added.