### PR TITLE
[RHCLOUD-20152] Order certain resources in applying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 test: envtest fmt vet
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -v -coverprofile cover.out
 
 
 ENVTEST = $(shell pwd)/bin/setup-envtest


### PR DESCRIPTION
Certain resources would do well to be applied after all others.
The following resources are relegated to the end of the apply list:

* Deployment
* Job
* CronJob

This prevents some deployments failing to spin up the first time due to missing resources such as ServiceAccounts and ConfigMaps