### PR TITLE
Fix linting issues

### DIFF
--- a/resourceCache/resourceCache.go
+++ b/resourceCache/resourceCache.go
@@ -1,4 +1,4 @@
-package resourceCache
+package resourcecache
 
 import (
 	"context"

--- a/resourceCache/resourceCache_test.go
+++ b/resourceCache/resourceCache_test.go
@@ -1,4 +1,4 @@
-package resourceCache
+package resourcecache
 
 import (
 	"context"
@@ -43,7 +43,7 @@ func init() {
 	utilruntime.Must(apps.AddToScheme(scheme))
 }
 
-func Run(signalHandler context.Context, enableLeaderElection bool, config *rest.Config) {
+func Run(_ context.Context, enableLeaderElection bool, config *rest.Config) {
 
 	_, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:           scheme,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,12 +6,10 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 	"math/big"
-	mrand "math/rand"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	core "k8s.io/api/core/v1"
@@ -28,10 +26,6 @@ const pCharSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789
 const rCharSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 const lCharSet = "abcdefghijklmnopqrstuvwxyz0123456789"
 
-func init() {
-	mrand.Seed(time.Now().UnixNano())
-}
-
 // Log is a null logger instance.
 var Log logr.Logger = logr.Discard()
 
@@ -39,7 +33,13 @@ func buildRandString(n int, charset string) string {
 	b := make([]byte, n)
 
 	for i := range b {
-		b[i] = charset[mrand.Intn(len(charset))]
+
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			panic(err)
+		}
+
+		b[i] = charset[n.Int64()]
 	}
 
 	return string(b)


### PR DESCRIPTION
- Replace math/rand with crypto/rand, following `golanci-lint` recommendation to replace rand library:

```
  Error: utils/utils.go:42:18: G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
  		b[i] = charset[mrand.Intn(len(charset))]
  		               ^
```

- Remove mixed case names in package names for `resourceCache`

```
resourceCache/resourceCache.go:1:9: var-naming: don't use MixedCaps in package name; resourceCache should be resourcecache (revive)
package resourceCache
        ^
```

- Remove unused parameters
```
resourcecache/resourceCache_test.go:46:10: unused-parameter: parameter 'signalHandler' seems to be unused, consider removing or renaming it as _ (revive)
func Run(signalHandler context.Context, enableLeaderElection bool, config *rest.Config) {
         ^
```