### PR TITLE
Fix Updater.Apply to preserve error chain

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -130,7 +130,7 @@ func (u *Updater) Apply(ctx context.Context, cl client.Client, obj client.Object
 			verb = "updating"
 		}
 
-		return fmt.Errorf("error %s resource %s %s: %s", verb, kind, meta.GetName(), err.Error())
+		return fmt.Errorf("error %s resource %s %s: %w", verb, kind, meta.GetName(), err)
 	}
 
 	return nil

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,11 +1,13 @@
 package utils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	core "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestConverterFuncs(t *testing.T) {
@@ -159,6 +161,36 @@ func TestMetaMutatorLabelsSingle(t *testing.T) {
 
 	assert.Equal(t, expected, b.GetLabels())
 }
+
+// Updater.Apply error wrapping
+// start
+type mockUpdateClient struct {
+	client.Client
+}
+
+func (m *mockUpdateClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return assert.AnError
+}
+
+// Asserts the error message format is unchanged
+func TestApplyErrorMessage(t *testing.T) {
+	obj := &core.ConfigMap{}
+	obj.SetName("test")
+	u := Updater(true)
+	err := u.Apply(t.Context(), &mockUpdateClient{}, obj)
+	assert.EqualError(t, err, "error updating resource *v1.ConfigMap test: assert.AnError general error for testing")
+}
+
+// Asserts the error chain is preserved, enabling errors.Is(), errors.As(), and k8serr.IsConflict().
+func TestApplyUnwrapsError(t *testing.T) {
+	obj := &core.ConfigMap{}
+	obj.SetName("test")
+	u := Updater(true)
+	err := u.Apply(t.Context(), &mockUpdateClient{}, obj)
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// end
 
 func TestMetaMutatorLabelsMulti(t *testing.T) {
 	initLabels := map[string]string{


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHCLOUD-46433

`Updater.Apply` was wrapping errors from `cl.Update()` and `cl.Create()` using  `%s`, which destroyed the original error type. Callers could not use `errors.Is()`, `errors.As()`, or `k8serr.IsConflict()` to inspect the  underlying error.                                                                                                                                                          
                                                                                                                                                                             
Fix: change `%s` to `%w` in `utils/utils.go`. The `.Error()` string is identical so this is not a breaking change for consumers.

Two regression tests are added to `utils/utils_test.go`:                                                                                                                     
  - **TestApplyErrorMessage**: asserts the error string is identical with `%w`,  confirming no breaking change for consumers                                                                                                                              
  - **TestApplyUnwrapsError**: asserts `errors.Is()` can traverse the error chain, which also covers `errors.As()` and `k8serr.IsConflict()` since they rely on the same unwrap mechanism 